### PR TITLE
Update queries.md to fix cover photo query

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -44,7 +44,7 @@ export default ({data: {allGooglePhotosAlbum}}) => {
         <>
             <h2>{albumNode.title}</h2>
             <div style={{width: 500}}>
-                <Img fluid={albumNode.cover.childImageSharp.fluid} />
+                <Img fluid={albumNode.cover.photo.childImageSharp.fluid} />
             </div>
             <div>{"Photos:"}</div>
             {albumNode.photos.map((photoNode) => (
@@ -62,9 +62,11 @@ export const pageQuery = graphql`
             nodes {
                 title
                 cover {
-                    childImageSharp {
-                        fluid(maxWidth: 500, quality: 100) {
-                            ...GatsbyImageSharpFluid
+                    photo {
+                        childImageSharp {
+                            fluid(maxWidth: 500, quality: 100) {
+                                ...GatsbyImageSharpFluid
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Cover photo query and component were missing the "photo" graphql node in between "cover" and "childImageSharp" causing the build to fail. Added the "photo" type to the query and object